### PR TITLE
configs: add bonnell chassis

### DIFF
--- a/configurations/bonnell.json
+++ b/configurations/bonnell.json
@@ -1,0 +1,16 @@
+{
+    "Exposes":[
+        {
+            "Name":"Compatible System",
+	    "Names":[
+		"ibm,bonnell"
+	    ],
+	    "Type":"IBMCompatibleSystem"
+	}
+    ],
+    "Name":"Bonnell Chassis",
+    "Probe":[
+	"com.ibm.ipzvpd.VSBP({'IM': [80, 0, 64, 0]})"
+    ],
+    "Type": "Chassis"
+}

--- a/meson.build
+++ b/meson.build
@@ -83,6 +83,7 @@ configs = [
     'bletchley_chassis.json',
     'bletchley_frontpanel.json',
     'blyth.json',
+    'bonnell.json',
     'ahw1um2riser.json',
     'aspower_u1a-d10550_psu.json',
     'aspower_u1a-d10800_psu.json',

--- a/schemas/ibm.json
+++ b/schemas/ibm.json
@@ -78,6 +78,7 @@
                     "type": "array",
                     "items": {
                         "enum": [
+                            "ibm,bonnell",
                             "ibm,everest",
                             "ibm,rainier-2u",
                             "ibm,rainier-1s4u",


### PR DESCRIPTION
Add a configuration for the Bonnell system enclosure.

Signed-off-by: jinuthomas <jinu.joy.thomas@in.ibm.com>